### PR TITLE
Moved provider into admin

### DIFF
--- a/src/admin/index.ts
+++ b/src/admin/index.ts
@@ -1,4 +1,6 @@
 import express from 'express'
+import provider from './providers'
+
 const adminRouter = express.Router()
 
 adminRouter.use('/*', (req, res, next) => {
@@ -6,8 +8,6 @@ adminRouter.use('/*', (req, res, next) => {
   next()
 })
 
-adminRouter.get('/providers', (req, res) => {
-  res.render('admin/providers')
-})
+adminRouter.use('/providers', provider)
 
 export { adminRouter }

--- a/src/admin/providers.ts
+++ b/src/admin/providers.ts
@@ -1,5 +1,6 @@
 import express from 'express'
 import * as goDaddy from '../providers/goDaddy'
+
 const providers = express.Router()
 
 providers.get('/', async (_, res) => {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,11 +1,10 @@
 import express from 'express'
 import adminRouter from './admin'
-import providers from './providers'
 import mappingRouter from './mapping'
 
 const apiRouter = express.Router()
+
 apiRouter.use('/admin', adminRouter.app)
-apiRouter.use('/providers', providers)
 apiRouter.use('/mappings', mappingRouter)
 
 export { apiRouter }


### PR DESCRIPTION
Since now we show providers api keys in `api/providers`  I feel it's better to move this endpoint in `admin/providers`