### PR TITLE
Fix undefined name

### DIFF
--- a/src/providers/goDaddy.ts
+++ b/src/providers/goDaddy.ts
@@ -5,6 +5,7 @@ import { Provider } from '../api/types/general'
 
 export const getDomains = async (): Promise<Provider> => {
   const service = 'https://api.godaddy.com'
+  const name = 'Godaddy'
   const serviceKeys = getProviderKeys()
 
   const defaultKey = { value: '' }


### PR DESCRIPTION
`/api/providers`
```
return {
    id: 'dns_gd',
    service,
    name, // name was undefined
    keys: { GD_Key, GD_Secret },
    domains
  }
```
