### PR TITLE
Bug: SSL Cert needs to send two commands for *.domain and .domain

### DIFF
--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -25,10 +25,10 @@ app.post('/sslCerts', async (req, res) => {
       const { value } = serviceKeys.find(d => d.key === key) || { value: '' }
       return acc + `${key}=${value} `
     }, '')
-    const { stderr } = await exec(
-      `${envVars} ./acme.sh/acme.sh --issue --dns ${service} -d ${selectedDomain} -d "*.${selectedDomain}" --force`
-    )
-
+    const acme = `./acme.sh/acme.sh --issue --dns ${service}`
+    const cert1 = `${acme} -d ${selectedDomain} --force`
+    const cert2 = `${acme} -d "*.${selectedDomain}" --force`
+    const { stderr } = await exec(`${envVars} & ${cert1} & ${cert2}`)
     if (stderr) {
       serviceResponse.success = false
       serviceResponse.message = `Could not create SSL Certs. Error: ${JSON.stringify(

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -26,7 +26,7 @@ app.post('/sslCerts', async (req, res) => {
       return acc + `${key}=${value} `
     }, '')
     const { stderr } = await exec(
-      `${envVars} ./acme.sh/acme.sh --issue --dns ${service} -d "*.${selectedDomain}" -d ${selectedDomain} --force`
+      `${envVars} ./acme.sh/acme.sh --issue --dns ${service} -d ${selectedDomain} -d "*.${selectedDomain}" --force`
     )
 
     if (stderr) {


### PR DESCRIPTION
Fix #102 
After reading the doc, if I don't misunderstand the first parameter has to be the **Main_domain** other parameters are **SAN_Domains**.
I can't test it due to the limitation as 5 by week however I can run `acme.sh --list` that show the list
