### PR TITLE
Duplicity of `npm run build`

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,5 +3,4 @@
 cd /home/dev/prodProxy
 git pull origin master
 npm run setup
-npm run build
 pm2 startOrRestart ./scripts/prod.config.js --env production --update-env


### PR DESCRIPTION
Since setup script include `npm run build` we don't need it anymore

**setup.sh:**
```bash
#!/bin/bash

npm install
if [ ! -d "./acme.sh" ] ; then
  git clone https://github.com/Neilpang/acme.sh.git
fi
cd ./acme.sh
./acme.sh --install
cd ../
npm run build
touch data.db`
```