### PR TITLE
Fix /api/mappings/download endpoint

### DIFF
--- a/src/api/mapping.ts
+++ b/src/api/mapping.ts
@@ -88,12 +88,6 @@ mappingRouter.get('/', (req, res) => {
   res.json(domains)
 })
 
-mappingRouter.get('/:id', (req, res) => {
-  const domains = getMappings()
-  const foundDomain = domains.find(e => e.id === req.params.id)
-  res.json(foundDomain || {})
-})
-
 mappingRouter.delete('/delete/:id', async (req, res) => {
   const domains = getMappings()
   const deletedDomain = domains.find(e => e.id === req.params.id)
@@ -162,6 +156,12 @@ mappingRouter.get('/download', (req, res) => {
   res.download(filePath, err => {
     console.log('Failed to download file', err)
   })
+})
+
+mappingRouter.get('/:id', (req, res) => {
+  const domains = getMappings()
+  const foundDomain = domains.find(e => e.id === req.params.id)
+  res.json(foundDomain || {})
 })
 
 export default mappingRouter


### PR DESCRIPTION
 Bug: Download config not working #254 
The bug was the client reach `/api/mappings/:id` before `/api/mappings/download`.
The path to download is not valid I guess that do not work on local.

Now the api works but I can't test on my server. A fresh install on the server speed up the cpu at 100% and crash.

Feel free to merge it and open a new issue to solve the path file if it not work.