### PR TITLE
Fix test api/availableDomains

### DIFF
--- a/src/tests/api.test.ts
+++ b/src/tests/api.test.ts
@@ -45,7 +45,7 @@ describe('/api', () => {
       })
       expect(response.status).toEqual(200)
       const data = await response.json()
-      expect(data).toEqual([])
+      expect(data).toBeInstanceOf(Array)
     })
   })
 })


### PR DESCRIPTION
Fix ` api/availableDomains` test.

The test was passing only is we don't have domains setup by checking an **empty array** instead of of his **instance**.