### PR TITLE
Deletebug

### DIFF
--- a/src/api/mapping.ts
+++ b/src/api/mapping.ts
@@ -104,6 +104,10 @@ mappingRouter.delete('/delete/:id', async (req, res) => {
   exec(
     `
       cd ${WORKPATH}
+      export PM2_HOME=/home/myproxy/.pm2
+      if command ls ${deletedDomain.fullDomain} | grep "package.json" &>/dev/null; then
+      pm2 delete ${deletedDomain.fullDomain}
+      fi
       rm -rf ${deletedDomain.fullDomain}
     `,
     { uid: gitUserId }


### PR DESCRIPTION
#264 

`export PM2_HOME=/home/myproxy/.pm2` had to be added script to get pm2 to work on the correct pm2 instance.

package.JSON is used to determine whether the app is currently running or not.