### PR TITLE
Updated Start Script for Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ app.get('/', (req, res) => {
 app.listen(process.env.PORT || 8123);
 ```
 
-7. Update scripts section of package.JSON with `"start": "node app.js"`
+7. Update scripts section of package.JSON with `"start:myproxy": "node app.js"`
 8. Run `git add .`
 9. Run `git commit -m "Initial Commit"`
 10. Run `git push origin master`

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,7 +73,7 @@ app.get('/', (req, res) => {
 app.listen(process.env.PORT || 8123);
 ```
 
-7. Update scripts section of Package.JSON with `"start": "node app.js"`
+7. Update scripts section of Package.JSON with `"start:myproxy": "node app.js"`
 8. Run `git add .`
 9. Run `git commit -m "Initial Commit"`
 10. Run `git push origin master`

--- a/src/api/mapping.ts
+++ b/src/api/mapping.ts
@@ -43,7 +43,7 @@ mappingRouter.post('/', async (req, res) => {
   prodConfigApp.name = fullDomain
   prodConfigApp.env_production.PORT = parseInt(req.body.port || portCounter, 10)
   prodConfigApp.script = 'npm'
-  prodConfigApp.args = 'start'
+  prodConfigApp.args = 'run start:myproxy'
   const prodConfig = {
     apps: prodConfigApp
   }


### PR DESCRIPTION
The "start" script is usually used for development purposes. Changing the server start script to "start:myproxy". 

