### PR TITLE
fix(data race): use readFileSync on startup to avoid test failure

### DIFF
--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -20,7 +20,7 @@ const updateCache = (table: string): void => {
   }
 }
 
-{
+try {
   const file = fs.readFileSync('./data.db')
   const fileData: DB = JSON.parse(file.toString() || '{}')
   data.serviceKeys = fileData.serviceKeys || []
@@ -30,6 +30,8 @@ const updateCache = (table: string): void => {
 
   domainToMapping = createDomainCache(data.mappings)
   idToMapping = createIdCache(data.mappings)
+} catch (err) {
+  console.error(`Error reading from data.db on startup, ${err}`)
 }
 
 // Typescript disable, because this is meant as a helper function to be used with N number of input types

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -31,7 +31,10 @@ try {
   domainToMapping = createDomainCache(data.mappings)
   idToMapping = createIdCache(data.mappings)
 } catch (err) {
-  console.error(`Error reading from data.db on startup, ${err}`)
+  console.error(
+    'File does not exist, but do not worry. File will be created on first save',
+    err
+  )
 }
 
 // Typescript disable, because this is meant as a helper function to be used with N number of input types

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -19,13 +19,8 @@ const updateCache = (table: string): void => {
   }
 }
 
-fs.readFile('./data.db', (err, file) => {
-  if (err) {
-    return console.log(
-      'File does not exist, but do not worry. File will be created on first save',
-      err
-    )
-  }
+{
+  const file = fs.readFileSync('./data.db')
   const fileData: DB = JSON.parse(file.toString() || '{}')
   data.serviceKeys = fileData.serviceKeys || []
   data.mappings = fileData.mappings || []
@@ -33,7 +28,7 @@ fs.readFile('./data.db', (err, file) => {
 
   domainToMapping = createDomainCache(data.mappings)
   idToMapping = createIdCache(data.mappings)
-})
+}
 
 // Typescript disable, because this is meant as a helper function to be used with N number of input types
 const getData = (table: string): unknown => {
@@ -51,13 +46,6 @@ const setData = (table: string, records: unknown): void => {
     if (err) {
       return console.log('writing to DB failed', err)
     }
-    console.log('successfully wrote to DB')
-
-    // The line below needs to be here. For some reason,
-    // data[table] value seems to be an old value and
-    // does not take the records value. Strange.
-    data[table] = records
-    updateCache(table)
   })
 }
 

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -31,7 +31,7 @@ try {
   domainToMapping = createDomainCache(data.mappings)
   idToMapping = createIdCache(data.mappings)
 } catch (err) {
-  console.error(
+  console.log(
     'File does not exist, but do not worry. File will be created on first save',
     err
   )


### PR DESCRIPTION
Before, when you ran the tests, there was a data race because when you start up the data.ts module, there was an asynchronous readFile call and after it read the file asynchronously it would overwrite the global state. This made it so we had to overwrite the global state after calling writeFile when running our tests for our tests to work. This change makes it so you don't have to worry about that problem anymore. We now synchronously read from the file and update the state so there's no longer a data race.