### PR TITLE
Refactor types

### DIFF
--- a/src/api/accessToken.ts
+++ b/src/api/accessToken.ts
@@ -24,7 +24,7 @@ accessTokensRouter.post('/', (req, res) => {
     id: `${uuidv4()}`
   }
   allAccessTokens.push(tokensObject)
-  setData('apiTokens', allAccessTokens)
+  setData('accessToken', allAccessTokens)
   res.json(tokensObject)
 })
 

--- a/src/helpers/cache.ts
+++ b/src/helpers/cache.ts
@@ -1,6 +1,6 @@
-import { Mapping, MappingObj } from '../types/general'
+import { Mapping, MappingById } from '../types/general'
 
-const createIdCache = (records: Mapping[]): MappingObj | {} => {
+const createIdCache = (records: Mapping[]): MappingById => {
   return records.reduce(
     (obj, item) => ({
       ...obj,
@@ -10,7 +10,7 @@ const createIdCache = (records: Mapping[]): MappingObj | {} => {
   )
 }
 
-const createDomainCache = (records: Mapping[]): MappingObj | {} => {
+const createDomainCache = (records: Mapping[]): MappingById => {
   return records.reduce(
     (obj, item) => ({
       ...obj,

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -13,7 +13,7 @@ const data: DB = {
 let domainToMapping: MappingById = {}
 let idToMapping: MappingById = {}
 
-const updateCache = (table: keyof typeof data): void => {
+const updateCache = (table: keyof DB): void => {
   if (table === 'mappings') {
     domainToMapping = createDomainCache(data.mappings)
     idToMapping = createIdCache(data.mappings)

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -31,7 +31,7 @@ try {
   domainToMapping = createDomainCache(data.mappings)
   idToMapping = createIdCache(data.mappings)
 } catch (err) {
-  console.error(
+  console.log(
     'File does not exist, but do not worry. File will be created on first save',
     err
   )

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -78,7 +78,7 @@ const getMappingByDomain = (domain: string): Mapping => {
   return domainToMapping[domain]
 }
 
-const getMappingById = (id: string): Mapping => {
+const getMappingById = (id: string): Mapping | undefined => {
   return idToMapping[id]
 }
 

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import { createDomainCache, createIdCache } from '../helpers/cache'
 import { DB, ServiceKey } from '../types/admin'
-import { Mapping, MappingObj, Domain, AccessToken } from '../types/general'
+import { Mapping, MappingById, Domain, AccessToken } from '../types/general'
 
 const data: DB = {
   serviceKeys: [],
@@ -10,10 +10,10 @@ const data: DB = {
   accessToken: []
 }
 
-let domainToMapping: MappingObj | {} = {}
-let idToMapping: MappingObj | {} = {}
+let domainToMapping: MappingById = {}
+let idToMapping: MappingById = {}
 
-const updateCache = (table: string): void => {
+const updateCache = (table: keyof typeof data): void => {
   if (table === 'mappings') {
     domainToMapping = createDomainCache(data.mappings)
     idToMapping = createIdCache(data.mappings)
@@ -37,13 +37,11 @@ try {
   )
 }
 
-// Typescript disable, because this is meant as a helper function to be used with N number of input types
-const getData = (table: string): unknown => {
+const getData = <T extends keyof DB>(table: T): DB[T] => {
   return data[table]
 }
 
-// Typescript disable, because this is meant as a helper function to be used with N number of input types
-const setData = (table: string, records: unknown): void => {
+const setData = <T extends keyof DB>(table: T, records: DB[T]): void => {
   data[table] = records
   updateCache(table)
 
@@ -72,7 +70,7 @@ const getAvailableDomains = (): Domain[] => {
 }
 
 const getAccessTokens = (): AccessToken[] => {
-  const initialData = getData('apiTokens') as AccessToken[] | undefined
+  const initialData = getData('accessToken') as AccessToken[] | undefined
   return initialData || []
 }
 

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -8,8 +8,8 @@ type Mapping = {
   fullDomain: string
 }
 
-type MappingObj = {
-  string: Mapping
+type MappingById = {
+  [mappingId: string]: Mapping
 }
 
 type Provider = {
@@ -52,7 +52,7 @@ type AccessToken = {
 
 export {
   Mapping,
-  MappingObj,
+  MappingById,
   Provider,
   Domain,
   ServiceResponse,


### PR DESCRIPTION
- Added type safety to getData, setData, updateCache by using conditional types
- Fixed typo bug that came up from adding this type safety (changed 'apiTokens' to 'accessToken')
- Renamed MappingObj to MappingById
- Fixed typo in MappingObj type where there was accidentally a property on the object called 'string' instead of an object with string keys