### PR TITLE
(fix) updating routes for myProxy

### DIFF
--- a/src/api/accessToken.ts
+++ b/src/api/accessToken.ts
@@ -1,10 +1,20 @@
 /* eslint @typescript-eslint/camelcase: 0 */
-import express from 'express'
+import express, { Response, NextFunction } from 'express'
 import uuidv4 from 'uuid/v4'
-import { AccessToken } from '../types/general'
+import { AccessToken, AuthenticatedRequest } from '../types/general'
 import { setData, getAccessTokens } from '../lib/data'
 
 const accessTokensRouter = express.Router()
+
+accessTokensRouter.use(
+  (req: AuthenticatedRequest, res: Response, next: NextFunction): void => {
+    if (!req.user.isAdmin) {
+      res.status(401).send('Unauthorized')
+      return
+    }
+    return next()
+  }
+)
 
 accessTokensRouter.post('/', (req, res) => {
   if (req.body.name.length < 2) {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -11,7 +11,7 @@ const apiRouter = express.Router()
 
 apiRouter.use(
   (req: AuthenticatedRequest, res: Response, next: NextFunction): void => {
-    if (!req.user || (!req.user.isUser && !req.user.isAdmin)) {
+    if (!req.user || (!req.user.isPseudoAdmin && !req.user.isAdmin)) {
       res.status(401).send('Unauthorized')
       return
     }

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -21,12 +21,12 @@ const setupAuth = (req, res, next): void => {
     adminPass === hashPass(pass) ||
     isCorrectCredentials(authorization, pass)
   ) {
-    req.user = { isAdmin: true, isUser: true }
+    req.user = { isAdmin: true, isPseudoAdmin: true }
     return next()
   }
   if (isValidAccessToken(authorization)) {
     {
-      req.user = { isUser: true }
+      req.user = { isPseudoAdmin: true }
     }
     return next()
   }

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -12,7 +12,7 @@ type Mapping = {
 interface AuthenticatedRequest extends Request {
   user?: {
     isAdmin: boolean
-    isUser: boolean
+    isPseudoAdmin: boolean
   }
 }
 


### PR DESCRIPTION
This addresses issue #262 

- Changed `req.user.isUser` to `req.user.isPseudoAdmin`
- Updated `accessToken` route to be admin only

Updated paths 

## Admin Paths
- `/api/admin`
- `/api/accessTokens`

## Pseudoadmin Paths
- `/api/mapping`
- `/api/logging`
- `/api/sshKeys`
- `/api/availableDomains`

## Public UI
- `/login`

## Admin UI 
- `/`
- `/admin`
- `/admin/accessToken`
- `/sshKeys`
