### PR TITLE
Handle errors for `POST /sslCerts` 

### DIFF
--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -34,7 +34,6 @@ app.post('/sslCerts', async (req, res) => {
         console.error('sslCertResponse', error)
         serviceResponse.success = false
         serviceResponse.message = 'createSslCerts error'
-        return serviceResponse
       }
     )
 
@@ -43,19 +42,20 @@ app.post('/sslCerts', async (req, res) => {
         console.error('cnameResponse', error)
         serviceResponse.success = false
         serviceResponse.message = 'setCnameRecords error'
-        return serviceResponse
       }
     )
-  }
 
-  const domains = getAvailableDomains()
-  const domain: Domain = {
-    domain: selectedDomain,
-    expiration: '<ssl expiration date will go here>',
-    provider: service
+    if (serviceResponse.success) {
+      const domains = getAvailableDomains()
+      const domain: Domain = {
+        domain: selectedDomain,
+        expiration: '<ssl expiration date will go here>',
+        provider: service
+      }
+      domains.push(domain)
+      setData('availableDomains', domains)
+    }
   }
-  domains.push(domain)
-  setData('availableDomains', domains)
 
   return res.json(serviceResponse)
 })


### PR DESCRIPTION
I refactored catch error for `POST /ssl Certs` to help at debugging
⚠️ Good to know:
Chrome have a [bug](https://config9.com/apps/google-chrome/chrome-dev-tools-fails-to-show-response-even-the-content-returned-has-header-content-typetext-html-charsetutf-8/) with the option `preserve log` that show `Failed to show response data` 
So it's recommended to use Firefox to check HTTP responses 

This refactor is for prepare #305 