### PR TITLE
Fix: subdomain names with upper case letters does not work properly

### DIFF
--- a/dataMigration.js
+++ b/dataMigration.js
@@ -1,0 +1,10 @@
+const fs = require('fs')
+const file = fs.readFileSync('./data.db')
+const fileData = JSON.parse(file.toString() || '{}')
+fileData.mappings = fileData.mappings.map(string => string.toLowerCase())
+const fileDataString = `${JSON.stringify(fileData, null, 2)}`
+fs.writeFile('./data.db', fileDataString, err => {
+  if (err) {
+    return console.log('writing to DB failed', err)
+  }
+})

--- a/dataMigration.js
+++ b/dataMigration.js
@@ -1,7 +1,12 @@
 const fs = require('fs')
 const file = fs.readFileSync('./data.db')
 const fileData = JSON.parse(file.toString() || '{}')
-fileData.mappings = fileData.mappings.map(string => string.toLowerCase())
+fileData.mappings = fileData.mappings.map(mapping => ({
+  ...mapping,
+  domain: mapping.domain.toLowerCase(),
+  subDomain: mapping.subDomain.toLowerCase(),
+  fullDomain: mapping.fullDomain.toLowerCase()
+}))
 const fileDataString = `${JSON.stringify(fileData, null, 2)}`
 fs.writeFile('./data.db', fileDataString, err => {
   if (err) {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "autofix": "npm run prettier:write && npm run eslint:fix",
     "server": "./scripts/setup.sh; pm2 startOrRestart ./scripts/prod.config.js --env production --update-env",
     "server:stop": "pm2 stop myProxy-prod",
-    "migration": "node ./dataMigration.js"
+    "migrate": "node ./dataMigration.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "lint": "npm run prettier:check && npm run eslint:check",
     "autofix": "npm run prettier:write && npm run eslint:fix",
     "server": "./scripts/setup.sh; pm2 startOrRestart ./scripts/prod.config.js --env production --update-env",
-    "server:stop": "pm2 stop myProxy-prod"
+    "server:stop": "pm2 stop myProxy-prod",
+    "migration": "node ./dataMigration.js"
   },
   "repository": {
     "type": "git",

--- a/src/api/mapping.ts
+++ b/src/api/mapping.ts
@@ -30,8 +30,8 @@ mappingRouter.post('/', async (req, res) => {
     return res.status(400).json({ message: 'Port cannot be smaller than 3001' })
   }
   const fullDomain = req.body.subDomain
-    ? `${req.body.subDomain}.${req.body.domain}`
-    : `${req.body.domain}`
+    ? `${req.body.subDomain}.${req.body.domain}`.toLowerCase()
+    : `${req.body.domain}`.toLowerCase()
   const existingSubDomain = getMappingByDomain(fullDomain)
   if (existingSubDomain)
     return res.status(400).json({
@@ -55,8 +55,8 @@ mappingRouter.post('/', async (req, res) => {
 
   const respond = (): void => {
     const mappingObject: Mapping = {
-      domain: req.body.domain,
-      subDomain: req.body.subDomain,
+      domain: req.body.domain.toLowerCase(),
+      subDomain: req.body.subDomain.toLowerCase(),
       port: req.body.port || `${portCounter}`,
       ip: req.body.ip || '127.0.0.1',
       id: uuid4(),

--- a/src/tests/integration/mapping.test.ts
+++ b/src/tests/integration/mapping.test.ts
@@ -17,8 +17,8 @@ describe('/api', () => {
     server.close()
   })
 
-  it('checks mappings for newly added mapping', async () => {
-    const subDomain = `testing${uuidv4()}`
+  it('checks mappings for newly added mapping and it converts domain and subdomain to lowercase', async () => {
+    const subDomain = `Testing${uuidv4()}`
     const domain = 'Rahul'
     const port = '5678'
     const postResponse = await mappingAdapter('/', 'POST', {
@@ -28,9 +28,11 @@ describe('/api', () => {
     })
     const postMapping = await postResponse.json()
     expect(postMapping.port).toEqual(port)
-    expect(postMapping.subDomain).toEqual(subDomain)
-    expect(postMapping.domain).toEqual(domain)
-    expect(postMapping.fullDomain).toEqual(`${subDomain}.${domain}`)
+    expect(postMapping.subDomain).toEqual(subDomain.toLowerCase())
+    expect(postMapping.domain).toEqual(domain.toLowerCase())
+    expect(postMapping.fullDomain).toEqual(
+      `${subDomain}.${domain}`.toLowerCase()
+    )
     const deleteResponse = await mappingAdapter(`/${postMapping.id}`, 'DELETE')
     expect(deleteResponse.status).toEqual(200)
     const getMapping = await mappingAdapter(`/${postMapping.id}`, 'GET')
@@ -135,8 +137,8 @@ describe('/api', () => {
       subDomain
     })
 
-    const firstFullDomain = `${subDomain}.${domain}`
-    const secondFullDomain = `${subDomain}.${secondDomain}`
+    const firstFullDomain = `${subDomain}.${domain}`.toLowerCase()
+    const secondFullDomain = `${subDomain}.${secondDomain}`.toLowerCase()
     const match1 = getMappingByDomain(firstFullDomain)
     const match2 = getMappingByDomain(secondFullDomain)
 


### PR DESCRIPTION

- Update codebase to convert subdomain and domain names to lowercase.
- Update test to reflect these changes.

Added a migration plan for existing database. Users can run `cp ./data.db ./data.db.backup` to back up their database. Then `npm run migration` to update their exisiting domains. However, users will not be able to view the status of the domain unless they delete and recreate the app. 