### PR TITLE
Block SSH shell access to git repositories

### DIFF
--- a/scripts/no-interactive-login
+++ b/scripts/no-interactive-login
@@ -1,0 +1,3 @@
+#!/bin/sh
+printf '%s\n' "Hi! You've successfully authenticated, but myProxy does not provide interactive shell access."
+exit 128

--- a/scripts/post-receive
+++ b/scripts/post-receive
@@ -6,4 +6,4 @@ git clean -f
 git checkout master
 git branch -D prod
 npm install
-pm2 startOrRestart deploy.config.js --env production --update-env
+sudo -u myproxy pm2 startOrRestart deploy.config.js --env production --update-env

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -32,6 +32,10 @@ if [ ! -d "/home/myproxy" ] ; then
   cp ./scripts/gitignore /home/myproxy/.scripts/.gitignore
   # Disable SSH MOTD message for git user
   touch /home/git/.hushlogin
+  # Add git-shell message
+  mkdir /home/git/git-shell-commands
+  cp ./scripts/no-interactive-login /home/git/git-shell-commands/no-interactive-login
+  chmod +x /home/git/git-shell-commands/no-interactive-login
   # fix file permissions
   chown myproxy:myproxy -R /home/myproxy/
   chown git:git -R /home/git/

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -30,6 +30,8 @@ if [ ! -d "/home/myproxy" ] ; then
   cp ./scripts/post-receive /home/myproxy/.scripts/post-receive
   cp ./scripts/pre-receive /home/myproxy/.scripts/pre-receive
   cp ./scripts/gitignore /home/myproxy/.scripts/.gitignore
+  # Disable SSH MOTD message for git user
+  touch /home/git/.hushlogin
   # fix file permissions
   chown myproxy:myproxy -R /home/myproxy/
   chown git:git -R /home/git/

--- a/src/api/mapping.ts
+++ b/src/api/mapping.ts
@@ -72,8 +72,11 @@ mappingRouter.post('/', async (req, res) => {
   if (!isProduction()) {
     return respond()
   }
+
+  // get user and group id to execute the commands with the correct permissions
   const gitUserId = await getGitUserId()
   const gitGroupId = await getGitGroupId()
+
   exec(
     `
       umask 002
@@ -128,8 +131,11 @@ mappingRouter.delete('/:id', async (req, res) => {
   const deletedDomain = getMappingById(req.params.id)
   deleteDomain(deletedDomain.fullDomain)
   if (!isProduction()) return res.json(deletedDomain)
+
+  // get user and group id to execute the commands with the correct permissions
   const gitUserId = await getGitUserId()
   const gitGroupId = await getGitGroupId()
+
   exec(
     `
       cd ${WORKPATH}

--- a/src/api/mapping.ts
+++ b/src/api/mapping.ts
@@ -129,6 +129,7 @@ mappingRouter.delete('/:id', async (req, res) => {
   deleteDomain(deletedDomain.fullDomain)
   if (!isProduction()) return res.json(deletedDomain)
   const gitUserId = await getGitUserId()
+  const gitGroupId = await getGitGroupId()
   exec(
     `
       cd ${WORKPATH}
@@ -138,7 +139,7 @@ mappingRouter.delete('/:id', async (req, res) => {
       fi
       rm -rf ${deletedDomain.fullDomain}
     `,
-    { uid: gitUserId }
+    { uid: gitUserId, gid: gitGroupId }
   ).then(() => {
     res.json(deletedDomain)
   })

--- a/src/api/mapping.ts
+++ b/src/api/mapping.ts
@@ -12,7 +12,7 @@ import {
 } from '../lib/data'
 import { Mapping } from '../types/general'
 import prodConfigure from '../../scripts/prod.config.js'
-import { getGitUserId } from '../helpers/getGitUser'
+import { getGitUserId, getGitGroupId } from '../helpers/getGitUser'
 import environment from '../helpers/environment'
 const mappingRouter = express.Router()
 const exec = util.promisify(cp.exec)
@@ -73,8 +73,10 @@ mappingRouter.post('/', async (req, res) => {
     return respond()
   }
   const gitUserId = await getGitUserId()
+  const gitGroupId = await getGitGroupId()
   exec(
     `
+      umask 002
       cd ${WORKPATH}
       mkdir ${fullDomain}
       git init ${fullDomain}
@@ -88,7 +90,7 @@ mappingRouter.post('/', async (req, res) => {
       git add .
       git commit -m "Initial Commit"
       `,
-    { uid: gitUserId }
+    { uid: gitUserId, gid: gitGroupId }
   )
     .then(() => {
       respond()

--- a/src/api/mapping.ts
+++ b/src/api/mapping.ts
@@ -61,7 +61,7 @@ mappingRouter.post('/', async (req, res) => {
       port: req.body.port || `${portCounter}`,
       ip: req.body.ip || '127.0.0.1',
       id: uuid4(),
-      gitLink: `myproxy@${req.body.domain}:${WORKPATH}/${fullDomain}`,
+      gitLink: `git@${req.body.domain}:${WORKPATH}/${fullDomain}`,
       fullDomain
     }
     domainKeys.push(mappingObject)

--- a/src/helpers/authorizedKeys.ts
+++ b/src/helpers/authorizedKeys.ts
@@ -2,16 +2,18 @@ import fs from 'fs'
 import environment from '../helpers/environment'
 
 const { isProduction } = environment
+const sshOptions =
+  'no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty'
 let authorizedKeys: Array<string> = []
 
 const updateSSHKey = (): void => {
   if (isProduction()) {
-    const file = fs.createWriteStream('/home/myproxy/.ssh/authorized_keys')
+    const file = fs.createWriteStream('/home/git/.ssh/authorized_keys')
     file.on('error', err => {
       console.log(err)
     })
     authorizedKeys.forEach(v => {
-      file.write(`${v}\n`)
+      file.write(`${sshOptions} ${v}\n`)
     })
     file.end()
   }

--- a/src/helpers/getGitUser.ts
+++ b/src/helpers/getGitUser.ts
@@ -3,12 +3,12 @@ import cp from 'child_process'
 const exec = util.promisify(cp.exec)
 
 const getGitUserId = async (): Promise<number> => {
-  const gitId = await exec('id -u git')
+  const gitId = await exec('id -u myproxy')
   return parseInt(gitId.stdout, 10)
 }
 
 const getGitGroupId = async (): Promise<number> => {
-  const gitId = await exec('getent group git | cut -d: -f3')
+  const gitId = await exec('getent group myproxy | cut -d: -f3')
   return parseInt(gitId.stdout, 10)
 }
 

--- a/src/helpers/getGitUser.ts
+++ b/src/helpers/getGitUser.ts
@@ -7,4 +7,9 @@ const getGitUserId = async (): Promise<number> => {
   return parseInt(gitId.stdout, 10)
 }
 
-export { getGitUserId }
+const getGitGroupId = async (): Promise<number> => {
+  const gitId = await exec('getent group git | cut -d: -f3')
+  return parseInt(gitId.stdout, 10)
+}
+
+export { getGitUserId, getGitGroupId }

--- a/src/helpers/getGitUser.ts
+++ b/src/helpers/getGitUser.ts
@@ -3,7 +3,7 @@ import cp from 'child_process'
 const exec = util.promisify(cp.exec)
 
 const getGitUserId = async (): Promise<number> => {
-  const gitId = await exec('id -u myproxy')
+  const gitId = await exec('id -u git')
   return parseInt(gitId.stdout, 10)
 }
 


### PR DESCRIPTION
This pull request contains changes to block shell access to the server through the SSH link used as the git repository for domains.
The access is blocked by setting up a `git` user account restricted to only Git-related activities through a limited shell tool called `git-shell` that comes with Git. [Reference](https://git-scm.com/book/en/v2/Git-on-the-Server-Setting-Up-the-Server).

What this PR does:

- Modify the `setup.sh` script to create the `git` user account in the `myproxy` group, and set the correct file permissions.
  - `git` user has restricted shell access through `git-shell`
  - adds sudoers rule so the `git` user can run `sudo -u myproxy pm2` without password
  - disable server MOTD for the `git`user so it doesn't print when someone tries to SSH into the server.
  - adds a script to print a message when someone tries to SSH into the server.

- Modify the `post-receive` script so the app is started by the `myproxy` user instead of `git`.

- Change the `exec` commands in `/src/api/mappings.ts` options to use the correct group id. (Added new helper function for this)

- Change the `authorized_keys` function to save the SSH keys under the `git` user and with additional options. 