### PR TITLE
Remove download button

### DIFF
--- a/src/api/mapping.ts
+++ b/src/api/mapping.ts
@@ -151,15 +151,6 @@ mappingRouter.delete('/:id', async (req, res) => {
   })
 })
 
-mappingRouter.get('/download', (req, res) => {
-  const filePath = `${WORKPATH}/${req.query.fullDomain}/deploy.config.js`
-  res.setHeader('Content-disposition', 'attachment; filename=deploy.config.js')
-  res.setHeader('Content-type', 'application/javascript')
-  res.download(filePath, err => {
-    console.log('Failed to download file', err)
-  })
-})
-
 mappingRouter.get('/:id', (req, res) => {
   const foundDomain = getMappingById(req.params.id)
   res.json(foundDomain || {})

--- a/src/public/client.ts
+++ b/src/public/client.ts
@@ -108,13 +108,6 @@ class MappingItem {
           ${data.gitLink}
         </small>
       </div>
-      <a
-        href="/api/mappings/download/?fullDomain=${data.fullDomain}"
-        target="_blank"
-        class="btn btn-sm btn-outline-success mr-3"
-      >
-        Download<i class="fa fa-download"></i>
-      </a>
       <button
         class="btn btn-sm btn-outline-danger mr-3 deleteButton"
         type="button"


### PR DESCRIPTION
This PR removes the download button and the API endpoint, so the users can't download the `deploy.config.js` file and modify it, which could lead to arbitrary script execution.