### PR TITLE
Run apps inside Docker containers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -479,6 +479,15 @@
         "@types/express": "*"
       }
     },
+    "@types/dockerode": {
+      "version": "2.5.34",
+      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-2.5.34.tgz",
+      "integrity": "sha512-LcbLGcvcBwBAvjH9UrUI+4qotY+A5WCer5r43DR5XHv2ZIEByNXFdPLo1XxR+v/BjkGjlggW8qUiXuVEhqfkpA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -1053,12 +1062,44 @@
         }
       }
     },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
         "tweetnacl": "^0.14.3"
+      }
+    },
+    "bl": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "body-parser": {
@@ -1155,6 +1196,15 @@
       "dev": true,
       "requires": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "buffer": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "buffer-from": {
@@ -1266,6 +1316,11 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "ci-info": {
       "version": "2.0.0",
@@ -1666,6 +1721,51 @@
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.3.0.tgz",
       "integrity": "sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==",
       "dev": true
+    },
+    "docker-modem": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-2.1.4.tgz",
+      "integrity": "sha512-vDTzZjjO1sXMY7m0xKjGdFMMZL7vIUerkC3G4l6rnrpOET2M6AOufM8ajmQoOB+6RfSn6I/dlikCUq/Y91Q1sQ==",
+      "requires": {
+        "debug": "^4.1.1",
+        "readable-stream": "^3.5.0",
+        "split-ca": "^1.0.1",
+        "ssh2": "^0.8.7"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "dockerode": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-3.2.1.tgz",
+      "integrity": "sha512-XsSVB5Wu5HWMg1aelV5hFSqFJaKS5x1aiV/+sT7YOzOq1IRl49I/UwV8Pe4x6t0iF9kiGkWu5jwfvbkcFVupBw==",
+      "requires": {
+        "docker-modem": "^2.1.0",
+        "tar-fs": "~2.0.1"
+      }
     },
     "doctrine": {
       "version": "3.0.0",
@@ -2467,6 +2567,11 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3265,6 +3370,11 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "ignore": {
       "version": "3.3.10",
@@ -4587,6 +4697,11 @@
           "dev": true
         }
       }
+    },
+    "mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "mri": {
       "version": "1.1.4",
@@ -6138,6 +6253,11 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
     },
+    "split-ca": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
+      "integrity": "sha1-bIOv82kvphJW4M0ZfgXp3hV2kaY="
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -6151,6 +6271,24 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "ssh2": {
+      "version": "0.8.9",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.8.9.tgz",
+      "integrity": "sha512-GmoNPxWDMkVpMFa9LVVzQZHF6EW3WKmBwL+4/GeILf2hFmix5Isxm7Amamo8o7bHiU0tC+wXsGcUXOxp8ChPaw==",
+      "requires": {
+        "ssh2-streams": "~0.4.10"
+      }
+    },
+    "ssh2-streams": {
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.4.10.tgz",
+      "integrity": "sha512-8pnlMjvnIZJvmTzUIIA5nT4jr2ZWNNVHwyXfMGdRJbug9TpI3kd99ffglgfSWqujVv/0gxwMsDn9j9RVst8yhQ==",
+      "requires": {
+        "asn1": "~0.2.0",
+        "bcrypt-pbkdf": "^1.0.2",
+        "streamsearch": "~0.1.2"
+      }
     },
     "sshpk": {
       "version": "1.16.1",
@@ -6205,6 +6343,11 @@
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
+    },
+    "streamsearch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
     "strict-uri-encode": {
       "version": "1.1.0",
@@ -6269,7 +6412,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -6335,6 +6477,41 @@
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^5.1.0"
+          }
+        }
+      }
+    },
+    "tar-fs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.1.tgz",
+      "integrity": "sha512-6tzWDMeroL87uF/+lin46k+Q+46rAJ0SyPGz7OW7wTgblI273hsBqk2C1j0/xNadNLKDTUL9BukSjB7cwgmlPA==",
+      "requires": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.0.0"
+      }
+    },
+    "tar-stream": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.3.tgz",
+      "integrity": "sha512-Z9yri56Dih8IaK8gncVPx4Wqt86NDmQTSh49XLZgjWpGZL9GK9HKParS2scqHCC4w6X9Gh2jwaU45V47XTKwVA==",
+      "requires": {
+        "bl": "^4.0.1",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         }
       }
@@ -6644,8 +6821,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util.promisify": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/node-fetch": "^2.5.0",
     "@types/uuid": "^3.4.5",
     "cookie-parser": "^1.4.4",
+    "dockerode": "^3.2.1",
     "dotenv": "^8.1.0",
     "ejs": "^2.6.2",
     "express": "^4.17.1",
@@ -48,6 +49,7 @@
     "uuid": "^3.3.3"
   },
   "devDependencies": {
+    "@types/dockerode": "^2.5.34",
     "@types/jest": "^24.0.17",
     "@types/node": "^12.7.1",
     "@typescript-eslint/eslint-plugin": "^2.0.0",

--- a/scripts/post-receive
+++ b/scripts/post-receive
@@ -1,9 +1,12 @@
 #!/bin/sh
 cd ..
 GIT_DIR='.git'
+DOMAIN=$(basename $(pwd))
 umask 002 && git reset --hard
 git clean -f
 git checkout master
 git branch -D prod
 npm install
-sudo -u myproxy pm2 startOrRestart deploy.config.js --env production --update-env
+echo "Starting the container..."
+curl --silent --unix-socket /var/run/docker.sock -X POST "http:/localhost/containers/${DOMAIN}/restart"
+echo "Your app is running at https://${DOMAIN}"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -96,4 +96,11 @@ if [ ! -f "./data.db" ] ; then
 fi
 
 # pull node docker image
-docker pull node:alpine
+if docker ps > /dev/null 2>&1; then
+  docker pull node:alpine
+else
+  echo "WARNING: Couldn't run docker commands"
+  echo "WARNING: Make sure your user has the right permissions"
+  echo "WARNING: Go to this link to setup docker to run without root"
+  echo "WARNING: https://docs.docker.com/engine/install/linux-postinstall/"
+fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Check if docker is installed and stop the script if it's not
+if ! command docker &> /dev/null; then
+  echo "myProxy requires Docker to run"
+  echo "Docker installation instructions: https://docs.docker.com/engine/install/"
+  exit
+fi
+
 if ! command node -v &>/dev/null; then
   sudo apt-get install curl
   curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -18,8 +18,11 @@ if [ ! -d "/home/myproxy" ] ; then
   # Add users
   sudo useradd -m -c "myproxy" myproxy -s /bin/bash -p $(echo $ADMIN | openssl passwd -1 -stdin) -d "/home/myproxy"
   sudo useradd -m -G myproxy -s $(which git-shell) -p $(echo $ADMIN | openssl passwd -1 -stdin) git
-  # Add sudoers rule for git user to run pm2 as myproxy, without password
-  echo "git ALL = (myproxy) NOPASSWD: /usr/bin/pm2" > /etc/sudoers.d/git
+  # Add myproxy and git to the docker group so they can run the commands
+  sudo groupadd docker
+  sudo usermod -aG docker myproxy
+  sudo usermod -aG docker git
+  newgrp docker
   # Create folders
   mkdir /home/myproxy/.ssh
   mkdir /home/git/.ssh

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -44,30 +44,21 @@ if ! user_exists myproxy; then
   echo "Creating user: myproxy"
   sudo useradd -m -c "myproxy" myproxy -s /bin/bash -p $(echo $ADMIN | openssl passwd -1 -stdin) -d "/home/myproxy"
   sudo usermod -aG docker myproxy
+  mkdir -p /home/myproxy/.ssh
+  mkdir -p /home/myproxy/.scripts
 fi
 
 if ! user_exists git; then
   echo "Creating user: git"
   sudo useradd -m -G myproxy -s $(which git-shell) -p $(echo $ADMIN | openssl passwd -1 -stdin) git
   sudo usermod -aG docker git
+  mkdir -p /home/git/.ssh
   # Disable SSH MOTD message for git user
   touch /home/git/.hushlogin
   # Add git-shell message
-  mkdir /home/git/git-shell-commands
+  mkdir -p /home/git/git-shell-commands
   cp ./scripts/no-interactive-login /home/git/git-shell-commands/no-interactive-login
   chmod +x /home/git/git-shell-commands/no-interactive-login
-fi
-
-if [ ! -d "/home/myproxy/.ssh" ]; then 
-  mkdir /home/myproxy/.ssh
-fi
-
-if [ ! -d "/home/myproxy/.scripts" ]; then 
-  mkdir /home/myproxy/.scripts
-fi
-
-if [ ! -d "/home/git/.ssh" ]; then 
-  mkdir /home/git/.ssh
 fi
 
 if [ -f "~/.ssh/authorized_keys" ]; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -78,6 +78,9 @@ cp ./scripts/gitignore /home/myproxy/.scripts/.gitignore
 # fix file permissions
 chown myproxy:myproxy -R /home/myproxy/
 chown git:git -R /home/git/
+# set the group permissions for /home/myproxy
+# 2 = set the setgid bit for the files so group permissions are inherited
+# 775 = set read+write permissions for the user and group
 chmod 2775 -R /home/myproxy/
 
 npm run build

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -75,6 +75,9 @@ if [ -f "~/.ssh/authorized_keys" ]; then
   cp ~/.ssh/authorized_keys /home/git/.ssh/authorized_keys
   # Prepend ssh options for authorized keys
   sed -i '/^ssh-rsa/s/^/no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty /' /home/git/.ssh/authorized_keys
+else
+  touch /home/myproxy/.ssh/authorized_keys
+  touch /home/git/.ssh/authorized_keys
 fi
 
 cp ./scripts/post-receive /home/myproxy/.scripts/post-receive

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -94,3 +94,6 @@ npm run build
 if [ ! -f "./data.db" ] ; then
   touch data.db
 fi
+
+# pull node docker image
+docker pull node:alpine

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,19 +1,35 @@
 #!/bin/bash
 
+# Helper functions
+command_exists() {
+	command -v "$@" > /dev/null 2>&1
+}
+
+user_exists() {
+  id "$1" &> /dev/null
+}
+
 # Check if docker is installed and stop the script if it's not
-if ! command docker &> /dev/null; then
+if ! command_exists docker; then
   echo "myProxy requires Docker to run"
   echo "Docker installation instructions: https://docs.docker.com/engine/install/"
   exit
 fi
 
-if ! command node -v &>/dev/null; then
+if ! command_exists node; then
+  echo "Installing node"
   sudo apt-get install curl
   curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
   sudo apt-get install -y nodejs
 fi
+
+if ! command_exists pm2; then
+  echo "Installing pm2"
+  npm install pm2 -g
+fi
+
 npm install
-npm install pm2 -g
+
 if [ ! -d "./acme.sh" ] ; then
   git clone https://github.com/Neilpang/acme.sh.git
   cd ./acme.sh
@@ -21,39 +37,57 @@ if [ ! -d "./acme.sh" ] ; then
   ./acme.sh --upgrade --auto-upgrade
   cd ../
 fi
-if [ ! -d "/home/myproxy" ] ; then
-  # Add users
+
+sudo groupadd -f docker
+
+if ! user_exists myproxy; then
+  echo "Creating user: myproxy"
   sudo useradd -m -c "myproxy" myproxy -s /bin/bash -p $(echo $ADMIN | openssl passwd -1 -stdin) -d "/home/myproxy"
-  sudo useradd -m -G myproxy -s $(which git-shell) -p $(echo $ADMIN | openssl passwd -1 -stdin) git
-  # Add myproxy and git to the docker group so they can run the commands
-  sudo groupadd docker
   sudo usermod -aG docker myproxy
+fi
+
+if ! user_exists git; then
+  echo "Creating user: git"
+  sudo useradd -m -G myproxy -s $(which git-shell) -p $(echo $ADMIN | openssl passwd -1 -stdin) git
   sudo usermod -aG docker git
-  newgrp docker
-  # Create folders
-  mkdir /home/myproxy/.ssh
-  mkdir /home/git/.ssh
-  mkdir /home/myproxy/.scripts
-  # Copy ssh keys and scripts
-  cp ~/.ssh/authorized_keys /home/myproxy/.ssh/authorized_keys
-  cp ~/.ssh/authorized_keys /home/git/.ssh/authorized_keys
-  cp ./scripts/post-receive /home/myproxy/.scripts/post-receive
-  cp ./scripts/pre-receive /home/myproxy/.scripts/pre-receive
-  cp ./scripts/gitignore /home/myproxy/.scripts/.gitignore
   # Disable SSH MOTD message for git user
   touch /home/git/.hushlogin
   # Add git-shell message
   mkdir /home/git/git-shell-commands
   cp ./scripts/no-interactive-login /home/git/git-shell-commands/no-interactive-login
   chmod +x /home/git/git-shell-commands/no-interactive-login
-  # fix file permissions
-  chown myproxy:myproxy -R /home/myproxy/
-  chown git:git -R /home/git/
-  chmod 2775 -R /home/myproxy/
+fi
+
+if [ ! -d "/home/myproxy/.ssh" ]; then 
+  mkdir /home/myproxy/.ssh
+fi
+
+if [ ! -d "/home/myproxy/.scripts" ]; then 
+  mkdir /home/myproxy/.scripts
+fi
+
+if [ ! -d "/home/git/.ssh" ]; then 
+  mkdir /home/git/.ssh
+fi
+
+if [ -f "~/.ssh/authorized_keys" ]; then
+  cp ~/.ssh/authorized_keys /home/myproxy/.ssh/authorized_keys
+  cp ~/.ssh/authorized_keys /home/git/.ssh/authorized_keys
   # Prepend ssh options for authorized keys
   sed -i '/^ssh-rsa/s/^/no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty /' /home/git/.ssh/authorized_keys
 fi
+
+cp ./scripts/post-receive /home/myproxy/.scripts/post-receive
+cp ./scripts/pre-receive /home/myproxy/.scripts/pre-receive
+cp ./scripts/gitignore /home/myproxy/.scripts/.gitignore
+
+# fix file permissions
+chown myproxy:myproxy -R /home/myproxy/
+chown git:git -R /home/git/
+chmod 2775 -R /home/myproxy/
+
 npm run build
+
 if [ ! -f "./data.db" ] ; then
   touch data.db
 fi

--- a/src/api/logs.ts
+++ b/src/api/logs.ts
@@ -1,65 +1,37 @@
 import express from 'express'
-import fs from 'fs'
 import environment from '../helpers/environment'
 import { getMappingByDomain } from '../lib/data'
+import { getContainerLogs } from '../helpers/docker'
 
 const logsRouter = express.Router()
 const { isProduction } = environment
 
-logsRouter.get('/err/:domain', (req, res) => {
-  const { domain } = req.params
+logsRouter.get('/:stream/:domain', async (req, res) => {
+  const { stream, domain } = req.params
+  const { follow, tail } = req.query
+
+  // Stream validation
+  if (stream !== 'stdout' && stream !== 'stderr') {
+    return res
+      .status(400)
+      .json({ message: 'stream param must be stdout or stderr' })
+  }
 
   if (isProduction()) {
     // Only search for domain when running in production. The test does not
     // require a valid domain since it only verifies the endpoint
     const { fullDomain } = getMappingByDomain(domain)
-    // Pipes the error log files to res
+    // Pipes the log to res
     res.setHeader('content-type', 'text/plain')
-    fs.createReadStream(`/home/myproxy/.pm2/logs/${fullDomain}-err.log`).pipe(
-      res
-    )
+    const logStream = await getContainerLogs(fullDomain, {
+      follow: Boolean(follow),
+      tail: Number(tail),
+      [stream]: true
+    })
+    logStream.pipe(res)
   } else {
     res.send('OK')
   }
-})
-
-logsRouter.get('/out/:domain', (req, res) => {
-  const { domain } = req.params
-
-  if (isProduction()) {
-    // Only search for domain when running in production. The test does not
-    // require a valid domain since it only verifies the endpoint
-    const { fullDomain } = getMappingByDomain(domain)
-    // Pipes the output log file to res. Console.Log from your app will appear here
-    res.setHeader('content-type', 'text/plain')
-    fs.createReadStream(`/home/myproxy/.pm2/logs/${fullDomain}-out.log`).pipe(
-      res
-    )
-  } else {
-    res.send('OK')
-  }
-})
-
-logsRouter.delete('/:domain', (req, res) => {
-  const { domain } = req.params
-
-  if (isProduction())
-    fs.writeFile(
-      `/home/myproxy/.pm2/logs/${domain}-out.log`,
-      'Log cleared\n',
-      err => {
-        if (err) console.log('Error deleting output log')
-      }
-    )
-  fs.writeFile(
-    `/home/myproxy/.pm2/logs/${domain}-err.log`,
-    'Log cleared\n',
-    err => {
-      if (err) console.log('Error deleting error log')
-    }
-  )
-
-  res.send('LOGS DELETED')
 })
 
 export default logsRouter

--- a/src/api/mapping.ts
+++ b/src/api/mapping.ts
@@ -30,7 +30,7 @@ const getNextPort = (map, start = 3002): number => {
   return getNextPort(map, start)
 }
 
-const { PORT, WORKPATH, isProduction } = environment
+const { WORKPATH, isProduction } = environment
 
 mappingRouter.post('/', async (req, res) => {
   const domainKeys = getMappings()

--- a/src/api/mapping.ts
+++ b/src/api/mapping.ts
@@ -3,8 +3,6 @@ import express from 'express'
 import uuid4 from 'uuid/v4'
 import util from 'util'
 import cp from 'child_process'
-import fs from 'fs'
-import path from 'path'
 import {
   setData,
   getMappings,
@@ -136,10 +134,10 @@ mappingRouter.delete('/:id', async (req, res) => {
   removeContainer(deletedDomain.fullDomain)
     .then(() => {
       // delete the domain folder
-      fs.rmdir(path.resolve(WORKPATH, deletedDomain.fullDomain), err => {
-        if (err) {
-          return res.status(500).json({ message: err.message })
-        }
+      exec(`
+        cd ${WORKPATH}
+        rm -rf ${deletedDomain.fullDomain}
+      `).then(() => {
         res.json(deletedDomain)
       })
     })

--- a/src/api/mapping.ts
+++ b/src/api/mapping.ts
@@ -93,7 +93,6 @@ mappingRouter.post('/', async (req, res) => {
       git config user.name "user"
       git add .
       git commit -m "Initial Commit"
-      echo "curl --silent --request GET --url http://localhost:${PORT}/api/mappings/${id}/start" >> ${fullDomain}/.git/hooks/post-receive
       `,
     { uid: gitUserId, gid: gitGroupId }
   )

--- a/src/api/mapping.ts
+++ b/src/api/mapping.ts
@@ -54,7 +54,7 @@ mappingRouter.post('/', async (req, res) => {
   const scriptPath = '.scripts'
 
   // Create a new container and get the id
-  const id = isProduction ? await createContainer(fullDomain, port) : uuid4()
+  const id = isProduction() ? await createContainer(fullDomain, port) : uuid4()
 
   const respond = (): void => {
     const mappingObject: Mapping = {

--- a/src/api/mapping.ts
+++ b/src/api/mapping.ts
@@ -136,7 +136,7 @@ mappingRouter.delete('/:id', async (req, res) => {
   removeContainer(deletedDomain.fullDomain)
     .then(() => {
       // delete the domain folder
-      fs.unlink(path.resolve(WORKPATH, deletedDomain.fullDomain), err => {
+      fs.rmdir(path.resolve(WORKPATH, deletedDomain.fullDomain), err => {
         if (err) {
           return res.status(500).json({ message: err.message })
         }

--- a/src/helpers/docker.ts
+++ b/src/helpers/docker.ts
@@ -1,0 +1,96 @@
+import Docker from 'dockerode'
+import path from 'path'
+import { Readable, PassThrough } from 'stream'
+import environment from '../helpers/environment'
+
+const docker = new Docker({ socketPath: '/var/run/docker.sock' })
+
+const getContainersList = async (): Promise<Docker.ContainerInfo[]> => {
+  const containers = await docker.listContainers({ all: true })
+  return containers
+}
+
+const getContainerLogs = async (
+  id: string,
+  options: Docker.ContainerLogsOptions
+): Promise<NodeJS.ReadableStream> => {
+  const container = docker.getContainer(id)
+  let logs = await container.logs(options)
+  if (!options.follow) {
+    // if follow = false, the logs are returned as a buffer
+    // so we need to convert into a stream
+    logs = Readable.from(logs)
+  }
+  const demuxedStream = new PassThrough()
+  container.modem.demuxStream(logs, demuxedStream, demuxedStream)
+  logs.on('end', () => demuxedStream.end())
+  return demuxedStream
+}
+
+const createContainer = async (
+  fullDomain: string,
+  port: number
+): Promise<string> => {
+  const workPath = path.resolve(environment.WORKPATH, fullDomain)
+  return docker
+    .createContainer({
+      Image: 'node:alpine',
+      name: fullDomain,
+      User: 'node',
+      ExposedPorts: {
+        '3000/tcp': {}
+      },
+      Tty: false,
+      WorkingDir: '/home/node/app',
+      Env: ['NODE_ENV=production', 'PORT=3000'],
+      HostConfig: {
+        Binds: [`${workPath}:/home/node/app`],
+        RestartPolicy: {
+          Name: 'on-failure',
+          MaximumRetryCount: 3
+        },
+        LogConfig: {
+          Type: 'json-file',
+          Config: {
+            'max-size': '10m',
+            'max-file': '1'
+          }
+        },
+        PortBindings: {
+          '3000/tcp': [
+            {
+              HostIp: '',
+              HostPort: port.toString()
+            }
+          ]
+        }
+      },
+      Cmd: ['node', '.']
+    })
+    .then(container => container.id)
+    .catch(err => err)
+}
+
+const startContainer = async (id: string): Promise<unknown> => {
+  const container = docker.getContainer(id)
+  return container.restart()
+}
+
+const stopContainer = async (id: string): Promise<unknown> => {
+  const container = docker.getContainer(id)
+  return container.stop()
+}
+
+const removeContainer = async (id: string): Promise<unknown> => {
+  const container = docker.getContainer(id)
+  return container.remove()
+}
+
+export {
+  getContainersList,
+  getContainerLogs,
+  createContainer,
+  startContainer,
+  stopContainer,
+  removeContainer
+}

--- a/src/helpers/docker.ts
+++ b/src/helpers/docker.ts
@@ -83,7 +83,7 @@ const stopContainer = async (id: string): Promise<unknown> => {
 
 const removeContainer = async (id: string): Promise<unknown> => {
   const container = docker.getContainer(id)
-  return container.remove()
+  return container.remove({ v: true, force: true })
 }
 
 export {

--- a/src/public/client.ts
+++ b/src/public/client.ts
@@ -48,13 +48,11 @@ class MappingItem {
     // The variables below are to hide log related icons when pm2 is not
     // being used to monitor the apps. These apps will not have status since
     // they are not managed by pm2.
-    let settingClass
     let logClass
     if (data.status === 'running') {
       iconClass = 'fa fa-circle mr-1 mt-1'
       iconColor = 'rgba(50,255,50,0.5)'
       logClass = 'fa fa-file-text-o ml-1 mt-1'
-      settingClass = 'ml-1 fa fa-cog'
     } else if (data.status === 'not started') {
       iconClass = ''
       iconColor = 'transparent'
@@ -62,7 +60,6 @@ class MappingItem {
       iconClass = 'fa fa-circle mr-1 mt-1'
       iconColor = 'rgba(255, 50, 50, 0.5)'
       logClass = 'fa fa-file-text-o ml-1 mt-1'
-      settingClass = 'ml-1 fa fa-cog'
     }
     mappingElement.classList.add(
       'list-group-item',

--- a/src/public/client.ts
+++ b/src/public/client.ts
@@ -15,6 +15,10 @@ type Status = {
   status: string
 }
 
+type ContainerResponse = {
+  message?: string
+}
+
 const create: HTMLElement = helper.getElement('.create')
 const hostSelector: HTMLElement = helper.getElement('#hostSelector')
 const domainList: HTMLElement = helper.getElement('.domainList')
@@ -46,7 +50,7 @@ class MappingItem {
     // they are not managed by pm2.
     let settingClass
     let logClass
-    if (data.status === 'online') {
+    if (data.status === 'running') {
       iconClass = 'fa fa-circle mr-1 mt-1'
       iconColor = 'rgba(50,255,50,0.5)'
       logClass = 'fa fa-file-text-o ml-1 mt-1'
@@ -109,6 +113,18 @@ class MappingItem {
         </small>
       </div>
       <button
+        class="btn btn-sm btn-outline-success mr-3 startButton"
+        type="button"
+      >
+        Start/Restart
+      </button>
+      <button
+        class="btn btn-sm btn-outline-warning mr-3 stopButton"
+        type="button"
+      >
+        Stop
+      </button>
+      <button
         class="btn btn-sm btn-outline-danger mr-3 deleteButton"
         type="button"
       >
@@ -116,6 +132,30 @@ class MappingItem {
       </button>
     `
 
+    const startButton = helper.getElement('.startButton', mappingElement)
+    startButton.onclick = (): void => {
+      if (confirm('Are you sure want to start/restart this domain?')) {
+        fetch(`/api/mappings/${data.id}/start`)
+          .then(response => (response.status !== 204 ? response.json() : {}))
+          .then((body: ContainerResponse) =>
+            body.message
+              ? alert(`ERROR: ${body.message}`)
+              : window.location.reload()
+          )
+      }
+    }
+    const stopButton = helper.getElement('.stopButton', mappingElement)
+    stopButton.onclick = (): void => {
+      if (confirm('Are you sure want to stop this domain?')) {
+        fetch(`/api/mappings/${data.id}/stop`)
+          .then(response => (response.status !== 204 ? response.json() : {}))
+          .then((body: ContainerResponse) =>
+            body.message
+              ? alert(`ERROR: ${body.message}`)
+              : window.location.reload()
+          )
+      }
+    }
     const delButton = helper.getElement('.deleteButton', mappingElement)
     delButton.onclick = (): void => {
       if (confirm('Are you sure want to delete this domain?')) {

--- a/src/public/client.ts
+++ b/src/public/client.ts
@@ -84,13 +84,13 @@ class MappingItem {
           <a
             class="${logClass}"
             style="font-size: 15px; color: rgba(255,50,50,0.5)"
-            href="/api/logs/err/${data.fullDomain}"
+            href="/api/logs/stderr/${data.fullDomain}"
           >
           </a>
           <a
             class="${logClass}"
             style="font-size: 15px; color: rgba(40,167,70,0.5)"
-            href="/api/logs/out/${data.fullDomain}"
+            href="/api/logs/stdout/${data.fullDomain}"
           >
           </a>
           <div class="dropright">

--- a/src/public/client.ts
+++ b/src/public/client.ts
@@ -93,20 +93,6 @@ class MappingItem {
             href="/api/logs/stdout/${data.fullDomain}"
           >
           </a>
-          <div class="dropright">
-            <a href="#" role="button" data-toggle="dropdown" class="btn-link">
-              <span class="${settingClass}" style="font-size: 15px"> </span>
-            </a>
-            <div class="dropdown-menu">
-              <button
-                type="button"
-                class="btn btn-link deleteLogButton"
-                style="color: rgba(255,50,50,1)"
-              >
-                Clear Logs
-              </button>
-            </div>
-          </div>
         </div>
         <small class="form-text text-muted" style="display: inline-block;">
           ${data.gitLink}
@@ -165,18 +151,6 @@ class MappingItem {
           headers: {
             'Content-Type': 'application/json'
           }
-        }).then(() => {
-          window.location.reload()
-        })
-      }
-    }
-    const clearLogButton = helper.getElement('.deleteLogButton', mappingElement)
-    clearLogButton.onclick = (): void => {
-      if (
-        confirm(`Are you sure you want to clear ${data.fullDomain}'s logs?`)
-      ) {
-        fetch(`/api/logs/${data.fullDomain}`, {
-          method: 'DELETE'
         }).then(() => {
           window.location.reload()
         })

--- a/src/tests/integration/log.test.ts
+++ b/src/tests/integration/log.test.ts
@@ -1,5 +1,4 @@
 import { startAppServer } from '../../server/server'
-import uuidv4 from 'uuid/v4'
 import { logAdapter } from '../helpers/logAdapter'
 
 const TEST_PORT = process.env.PORT || 50608
@@ -18,19 +17,19 @@ describe('/api/logs', () => {
 
   it('checks that output logs endpoint exists', async () => {
     const fullDomain = 'Cloud.Walker.com'
-    const logResponse = await logAdapter(`/out/${fullDomain}`, 'GET')
+    const logResponse = await logAdapter(`/stdout/${fullDomain}`, 'GET')
     expect(logResponse.status).toEqual(200)
   })
 
   it('checks that error logs endpoint exists', async () => {
     const fullDomain = 'Luke.Walker.com'
-    const logResponse = await logAdapter(`/err/${fullDomain}`, 'GET')
+    const logResponse = await logAdapter(`/stderr/${fullDomain}`, 'GET')
     expect(logResponse.status).toEqual(200)
   })
 
-  it('checks the delete endpoint exists', async () => {
-    const fullDomain = `${uuidv4()}.walker.com`
-    const logResponse = await logAdapter(`/${fullDomain}`, 'DELETE')
-    expect(logResponse.status).toEqual(200)
+  it('checks that unknown stream param returns an error', async () => {
+    const fullDomain = 'Luke.Walker.com'
+    const logResponse = await logAdapter(`/somestream/${fullDomain}`, 'GET')
+    expect(logResponse.status).toEqual(400)
   })
 })


### PR DESCRIPTION
Closes #377  
Closes #281

This PR will change the apps process management from `pm2` to `docker`, running the apps inside containers to achieve better isolation, this way protecting the main system from malicious apps.

Now docker is a requirement to run myProxy.

There's been a lot of changes, so read and review this PR carefully. I'm always open to your suggestions or questions.

### PR Summary

- [x] Create a new container when a new domain is created.
    - [x] Bind the correct port for the domain to the container.
    - [x] Pass the app port as a environment variable to the container.
    - [x] Bind the domain directory to a folder inside the container.
    - [x] Set the container default command to start the app.
- [x] Start the apps using a Docker container instead of `pm2` when the user pushes a new commit.
- [x] Get the container logs (stdout and stderr).
- [x] Get existing containers list and status (running or stopped).
- [x] Stop and delete the container when domain is deleted.
- [x] Start/Restart/Stop containers through the client

## Changed

- `setup.sh` script
    - checks if `docker` is installed before executing, exiting if it's not
    - added more checks so the script does not stop halfway and does not executes unnecessary commands
    - pulls the necessary node docker image (`node:alpine` ([Alpine](https://alpinelinux.org/) is a lightweight linux distro, the image is based on that))

- `post-receive` script
    - starts the app container by sending a request through `curl` to the docker socket on the machine

- `api/mappings.ts`
    - replaced every use of `pm2` to use `docker` instead, using it's API instead of exec commands
    - when a domain is created, a new container is created with all the needed configurations like port and directory bindings
    - the domain id is set to be the same as the container id
    - on a `git push` the container is started through the `post-receive`script
    - the delete feature was changed to also remove the container
    - the apps are started  by running `node .` in the app directory. For this to work, `package.json` needs to be configured correctly by setting the app entry point file in the `main` property (for example `"main": "index.js"`).

- `api/logs.ts`
    - merged the `stdout` and `stderr` endpoints into a single one
    - now returns the logs from docker

- `public/client.ts`
    - changed the logs buttons to work with the new parameters
    - changed the domain status check to the docker equivalent

## Added

- new package dependency: [`dockerode`](https://github.com/apocas/dockerode/), used to communicate with docker through it's API

- new docker helper functions in `helpers/docker.ts`

- new query params for the logs api
    - `follow: boolean`: works like `heroku logs tail` where the log keeps updating with new changes. Does not work in the browser. Useful in the terminal when used with `curl`.
    - `tail: number`: returns the last n lines from the log.

- new start and stop buttons in the client webpage, with the respective endpoints in the mappings api
    - start/restart: `/api/mappings/{id}/start`
    - stop: `/api/mappings/{id}/stop`

![image](https://user-images.githubusercontent.com/16023489/92260317-19a22b80-eeae-11ea-8931-0ecb3d280349.png)

## Removed

- clear logs feature
    - docker doesn't provide an easy way to clear it's logs, so I though better to remove this
    - as an alternative, we can get the log's tail (last n lines) by a query param in the url: `/api/logs/{stream}/{domain}?tail={numLines}`

- `deploy.config.js` is not needed anymore, all the domain configs are set when the container is created

## Possible features to be developed in the future

1. Add tests for the docker integration (would this require the dev/test env to have docker installed in their system?)
2. Integrate the c0d3-cli tool to deploy domains through the api