### PR TITLE
Use npm to start app inside the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ app.get('/', (req, res) => {
 app.listen(process.env.PORT || 8123);
 ```
 
-7. Update the `main` field in `package.json` with the filename of your app entry point: `"main": "app.js"`
+7. Update the `scripts` section in `package.json` with your app entry point command, under `start`: `"start": "node app.js"`
 8. Run `git add .`
 9. Run `git commit -m "Initial Commit"`
 10. Run `git push origin master`

--- a/src/helpers/docker.ts
+++ b/src/helpers/docker.ts
@@ -66,7 +66,7 @@ const createContainer = async (
           ]
         }
       },
-      Cmd: ['node', '.']
+      Cmd: ['npm', 'run', 'start']
     })
     .then(container => container.id)
     .catch(err => err)


### PR DESCRIPTION
While building the containers feature, I was following [Node's Docker best practices document](https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md#cmd), and it says:

> When creating an image, you can bypass the package.json's start command and bake it directly into the image itself. First off this reduces the number of processes running inside of your container. Secondly it causes exit signals such as SIGTERM and SIGINT to be received by the Node.js process instead of npm swallowing them.

This seemed like a good idea at the start, but I forgot an important point that was brought up to me: what if the app needs building/compiling?

So this PR fixes this issue, by changing the `CMD` section in the container creation, to start the app using `npm run start`. This allows the user to setup the additional steps it's app might need to run.

The readme was also updated to reflect this change.